### PR TITLE
fix: read chunk data only right before sending

### DIFF
--- a/packages/s3-uploads-client/src/manager.ts
+++ b/packages/s3-uploads-client/src/manager.ts
@@ -96,18 +96,18 @@ export class UploadManager {
 
         // For multipart upload, extract part from file and format a chunk that will
         // be passed to the UploadManager
-        const fileBuffer = await u.file.arrayBuffer()
         const parts = Array(u.partsCount)
           .fill(null)
           .map<UploadChunk>((_, idx) => {
             const start = idx * u.chunkSize
             const end = start + u.chunkSize
-            const filePart = fileBuffer.slice(start, end)
 
             return {
               uploadMode: UploadMode.Multipart,
               uploadType: u.uploadType,
-              filePart,
+              start,
+              end,
+              file: u.file,
               key: u.key,
               uploadId: u.uploadId,
               partNumber: idx + 1,
@@ -423,7 +423,7 @@ export class UploadManager {
     )
     const response = await fetch(request.url, {
       method: 'PUT',
-      body: chunk.filePart,
+      body: chunk.file.slice(chunk.start, chunk.end),
       headers,
       signal: abortController.signal,
     })

--- a/packages/s3-uploads-client/src/types.ts
+++ b/packages/s3-uploads-client/src/types.ts
@@ -61,7 +61,9 @@ export interface MultipartUploadChunk {
   uploadType: UploadType
   uploadId: string
   partNumber: number
-  filePart: ArrayBuffer
+  start: number
+  end: number
+  file: File
   key: string
 }
 export interface SingleFileUploadChunk {


### PR DESCRIPTION
This way we are not keeping the whole file in memory which may fail on large files.

Closes #5 